### PR TITLE
Add LoginStart and StatusRequest packets

### DIFF
--- a/Sources/SwiftcraftLibrary/Networking/Handler/DisplayPacketHandler.swift
+++ b/Sources/SwiftcraftLibrary/Networking/Handler/DisplayPacketHandler.swift
@@ -10,21 +10,33 @@ class DisplayPacketHandler: ChannelInboundHandler {
     ///     - context: `ChannelHandlerContext`
     ///     - data: `NIOAny` which can be unwrapped to have a `Packet`
     public func channelRead(context: ChannelHandlerContext, data: NIOAny) {
-        let rawPacket = self.unwrapInboundIn(data)
-        print("Packet ID: \(rawPacket.id)".blue)
+        let packet = self.unwrapInboundIn(data)
+        print("Packet ID: \(packet.id)".green)
 
-        switch rawPacket.id {
-            case 0x00:
-                let packet = rawPacket as! Handshake
+        switch packet {
+            case is Handshake:
+                let packet = packet as! Handshake
                 print("Protocol Version: \(packet.version)".blue)
                 print("Server Address: \(packet.address)".blue)
                 print("Server Port: \(packet.port)".blue)
                 print("Intention: \(packet.intention)".blue)
+                if packet.intention == 1 {
+                    playerState = .status
+                } else if packet.intention == 2 {
+                    playerState = .login
+                }
+                break
+            case is StatusRequest:
+                print("Status Packet".blue)
+                break
+            case is LoginStart:
+                let packet = packet as! LoginStart
+                print("Name: \(packet.name)".blue)
                 break
             default:
-                print("Unkown Packet ID".red)
+                print("Unknown Packet Type: \(type(of: packet))")
         }
 
-        context.fireChannelRead(wrapInboundOut(rawPacket))
+        context.fireChannelRead(wrapInboundOut(packet))
     }
 }

--- a/Sources/SwiftcraftLibrary/Networking/Packet/LoginStart.swift
+++ b/Sources/SwiftcraftLibrary/Networking/Packet/LoginStart.swift
@@ -1,0 +1,36 @@
+import Foundation
+import NIO
+
+/// # The Minecraft Login Start `Packet`
+///
+/// ## ID
+/// The `Packet`.`id` for the Minecraft Login Start Packet is 0x00
+///
+/// ## Definition
+///
+/// Field Name       | Datatype                                  | Decoder Arguments | Notes
+/// -----------------|-------------------------------------------|-------------------|--------------------
+/// Name             | `PacketData`.`varString`                  |                   | Player's username
+///
+/// - note: The protocol claims that name is a `PacketData`.`string` of length 16, but I have found it to be a `PacketData`.`varString`.
+class LoginStart: Packet {
+    /// LoginStart Initializer
+    init() {
+        super.init(
+            id: 0x00,
+            definition: [
+                (name: "name", type: .varString, args: nil),
+            ],
+            data: [:]
+        )
+    }
+    /// Getter and setter for `LoginStart`.`data["name"]`.
+    var name: String {
+        get {
+            return self.data["name"] as! String
+        }
+        set(value) {
+            self.data["name"] = value
+        }
+    }
+}

--- a/Sources/SwiftcraftLibrary/Networking/Packet/StatusRequest.swift
+++ b/Sources/SwiftcraftLibrary/Networking/Packet/StatusRequest.swift
@@ -1,0 +1,20 @@
+import Foundation
+import NIO
+
+/// # The Minecraft Server Bound Status Request `Packet`
+///
+/// ## ID
+/// The `Packet`.`id` for the Minecraft Server Bound Status Request Packet is 0x00
+///
+/// ## Definition
+/// empty
+class StatusRequest: Packet {
+    /// Server Bound Status Request Initializer
+    init() {
+        super.init(
+            id: 0x00,
+            definition: [],
+            data: [:]
+        )
+    }
+}


### PR DESCRIPTION
This PR adds a couple more serverbound Packets as we prepare to send clientbound packets.

- Refine PacketID 0x00 casting
- Add LoginStart Packet
- Add StatusRequest Packet
- Display LoginStart and StatusRequest
